### PR TITLE
feat: add MinuteZen landing page scaffold

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --ink: #1f2937;
+  --muted: #f3f4f6;
+  --line: #e5e7eb;
+}
+
+body {
+  @apply antialiased text-gray-800 bg-white;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import './globals.css'
+import type { Metadata } from 'next'
+import { ReactNode } from 'react'
+
+export const metadata: Metadata = {
+  title: 'MinuteZen — Harmony of Body, Peace of Mind',
+  description: 'Daily yoga & meditation for body and mind.',
+  openGraph: {
+    title: 'MinuteZen — Harmony of Body, Peace of Mind',
+    description: 'Daily yoga & meditation for body and mind.',
+  },
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="font-sans">
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,25 @@
+import TopStrip from '../components/TopStrip'
+import Header from '../components/Header'
+import Hero from '../components/Hero'
+import Benefits from '../components/Benefits'
+import Courses from '../components/Courses'
+import LiveOnDemand from '../components/LiveOnDemand'
+import BottomCta from '../components/BottomCta'
+import Footer from '../components/Footer'
+
+export default function Page() {
+  return (
+    <>
+      <TopStrip />
+      <Header />
+      <main>
+        <Hero />
+        <Benefits />
+        <Courses />
+        <LiveOnDemand />
+        <BottomCta />
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/components/Benefits.tsx
+++ b/components/Benefits.tsx
@@ -1,0 +1,69 @@
+// Section: Benefits
+import Image from 'next/image'
+import Icon, { IconName } from './Icon'
+
+const items: { icon: IconName; title: string; text: string }[] = [
+  { icon: 'mind', title: 'Stress Relief', text: 'Lorem ipsum dolor sit amet.' },
+  { icon: 'sleep', title: 'Sleep', text: 'Lorem ipsum dolor sit amet.' },
+  { icon: 'focus', title: 'Focus', text: 'Lorem ipsum dolor sit amet.' },
+  { icon: 'mobility', title: 'Mobility', text: 'Lorem ipsum dolor sit amet.' },
+  { icon: 'breath', title: 'Breath', text: 'Lorem ipsum dolor sit amet.' },
+  { icon: 'spark', title: 'Energy', text: 'Lorem ipsum dolor sit amet.' },
+]
+
+export default function Benefits() {
+  const left = items.slice(0, 3)
+  const right = items.slice(3)
+  return (
+    <section className="py-20" aria-labelledby="benefits-heading">
+      <h2 id="benefits-heading" className="sr-only">
+        Benefits
+      </h2>
+      <div className="grid max-w-7xl mx-auto gap-12 px-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="flex flex-col gap-8">
+          {left.map((item) => (
+            <BenefitItem key={item.title} align="left" {...item} />
+          ))}
+        </div>
+        <div className="flex items-center justify-center">
+          <div className="relative p-6 bg-white rounded-lg shadow">
+            <span className="absolute -z-10 inset-0 flex items-center justify-center">
+              <span className="w-40 h-40 rounded-full bg-muted" />
+            </span>
+            <Image
+              src="https://placehold.co/200x200"
+              alt="Meditation pose"
+              width={200}
+              height={200}
+            />
+          </div>
+        </div>
+        <div className="flex flex-col gap-8">
+          {right.map((item) => (
+            <BenefitItem key={item.title} align="right" {...item} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function BenefitItem({ icon, title, text, align }: { icon: IconName; title: string; text: string; align: 'left' | 'right' }) {
+  return (
+    <div className={`relative flex items-start gap-4 ${align === 'right' ? 'lg:pl-8' : 'lg:pr-8'}`}>
+      {align === 'right' && (
+        <span className="hidden lg:block absolute right-full top-5 w-8 border-t border-dashed border-line" />
+      )}
+      <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-muted">
+        <Icon name={icon} className="w-5 h-5" />
+      </span>
+      <div>
+        <h3 className="font-medium">{title}</h3>
+        <p className="text-sm text-gray-600">{text}</p>
+      </div>
+      {align === 'left' && (
+        <span className="hidden lg:block absolute left-full top-5 w-8 border-t border-dashed border-line" />
+      )}
+    </div>
+  )
+}

--- a/components/BottomCta.tsx
+++ b/components/BottomCta.tsx
@@ -1,0 +1,25 @@
+// Section: BottomCta
+import Icon from './Icon'
+
+export default function BottomCta() {
+  return (
+    <section className="py-20" aria-labelledby="cta-heading">
+      <div className="max-w-7xl mx-auto px-4">
+        <div className="flex flex-col items-start gap-6 rounded-xl bg-ink p-8 text-white md:flex-row md:items-center md:justify-between md:p-12">
+          <div className="flex items-center gap-3">
+            <Icon name="lotus" className="h-8 w-8" />
+            <h2 id="cta-heading" className="text-2xl font-semibold">
+              Visiter le site
+            </h2>
+          </div>
+          <a
+            href="#"
+            className="rounded-full bg-white px-6 py-3 text-sm text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
+          >
+            Découvrir les cours
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/Courses.tsx
+++ b/components/Courses.tsx
@@ -1,0 +1,57 @@
+// Section: Courses
+import Image from 'next/image'
+
+const courses = [
+  {
+    title: 'Morning Flow',
+    text: 'Lorem ipsum dolor sit amet.',
+    img: 'https://placehold.co/400x400?text=Course+1',
+  },
+  {
+    title: 'Evening Calm',
+    text: 'Lorem ipsum dolor sit amet.',
+    img: 'https://placehold.co/400x400?text=Course+2',
+  },
+  {
+    title: 'Mindful Breathing',
+    text: 'Lorem ipsum dolor sit amet.',
+    img: 'https://placehold.co/400x400?text=Course+3',
+  },
+  {
+    title: 'Deep Stretch',
+    text: 'Lorem ipsum dolor sit amet.',
+    img: 'https://placehold.co/400x400?text=Course+4',
+  },
+]
+
+export default function Courses() {
+  return (
+    <section className="py-20" aria-labelledby="courses-heading">
+      <div className="max-w-7xl mx-auto px-4 text-center">
+        <h2 id="courses-heading" className="text-3xl font-bold">
+          Explore our Yoga &amp; Meditation Course Collection.
+        </h2>
+        <p className="mt-4 max-w-3xl mx-auto text-gray-600">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </p>
+        <div className="mt-10 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          {courses.map((c) => (
+            <a
+              key={c.title}
+              href="#"
+              className="group block overflow-hidden rounded-lg border border-line focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink hover:shadow-lg"
+            >
+              <div className="relative aspect-square">
+                <Image src={c.img} alt={c.title} fill className="object-cover" />
+              </div>
+              <div className="p-4 text-left">
+                <h3 className="font-medium group-hover:underline">{c.title}</h3>
+                <p className="text-sm text-gray-600">{c.text}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,53 @@
+// Section: Footer
+import Icon from './Icon'
+
+export default function Footer() {
+  return (
+    <footer className="mt-20 border-t border-line" aria-labelledby="footer-heading">
+      <h2 id="footer-heading" className="sr-only">
+        Footer
+      </h2>
+      <div className="max-w-7xl mx-auto grid grid-cols-1 gap-8 px-4 py-12 md:grid-cols-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <Icon name="lotus" className="h-6 w-6" />
+            <span className="font-semibold">MinuteZen</span>
+          </div>
+          <p className="mt-2 text-sm text-gray-600">Lorem ipsum dolor sit amet.</p>
+        </div>
+        <div>
+          <h3 className="font-medium">Quick Links</h3>
+          <ul className="mt-4 space-y-2 text-sm">
+            {['Home', 'About', 'Courses', 'Pages', 'Blog', 'Contact'].map((link) => (
+              <li key={link}>
+                <a
+                  href="#"
+                  className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
+                >
+                  {link}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-medium">Newsletter</h3>
+          <form className="mt-4 flex flex-col gap-2 sm:flex-row">
+            <input
+              type="email"
+              placeholder="Email"
+              className="w-full rounded border border-line px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ink"
+            />
+            <button
+              type="submit"
+              className="rounded bg-ink px-4 py-2 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
+            >
+              Subscribe
+            </button>
+          </form>
+        </div>
+      </div>
+      <div className="border-t border-line py-4 text-center text-sm">© 2024 MinuteZen</div>
+    </footer>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,33 @@
+// Section: Header
+import Icon from './Icon'
+
+export default function Header() {
+  const nav = ['Home', 'About', 'Courses', 'Pages', 'Blog', 'Contact']
+  return (
+    <header className="border-b border-line">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3 md:px-6">
+        <div className="flex items-center gap-2">
+          <Icon name="lotus" className="w-6 h-6" />
+          <span className="font-semibold">MinuteZen</span>
+        </div>
+        <nav className="hidden md:flex gap-6 text-sm">
+          {nav.map((item) => (
+            <a key={item} href="#" className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink">
+              {item}
+            </a>
+          ))}
+        </nav>
+        <div className="flex items-center gap-4">
+          <span className="md:hidden text-sm">Menu</span>
+          <a
+            href="#"
+            className="hidden md:inline-flex items-center gap-1 rounded-full border border-ink px-4 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
+          >
+            Visiter le site
+            <Icon name="arrow-up-right" className="w-4 h-4" />
+          </a>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,49 @@
+// Section: Hero
+import Image from 'next/image'
+
+export default function Hero() {
+  return (
+    <section className="relative overflow-hidden rounded-t-3xl" aria-labelledby="hero-heading">
+      <div className="absolute inset-0">
+        <Image
+          src="https://placehold.co/1200x800"
+          alt="Beach"
+          fill
+          className="object-cover"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-blue-200/30" />
+      </div>
+      <div className="relative min-h-[70vh] flex flex-col items-center justify-center text-center px-4 py-20 gap-6">
+        <p className="text-sm uppercase tracking-wider">Daily Yoga &amp; Meditation</p>
+        <h1 id="hero-heading" className="text-4xl md:text-6xl font-bold leading-tight max-w-2xl">
+          HARMONY OF BODY, PEACE OF MIND.
+        </h1>
+        <p className="max-w-md text-sm md:text-base">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        <div className="flex gap-4">
+          <a
+            href="#"
+            className="rounded-full bg-ink px-6 py-3 text-white text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
+          >
+            Commencer
+          </a>
+          <a
+            href="#"
+            className="rounded-full px-6 py-3 text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
+          >
+            Découvrir
+          </a>
+        </div>
+        <div className="relative mt-10">
+          <div className="absolute -inset-x-10 bottom-0 top-10 bg-gradient-to-r from-blue-100 to-transparent blur-3xl rounded-full" />
+          <Image
+            src="https://placehold.co/300x300"
+            alt="Person meditating"
+            width={300}
+            height={300}
+            className="relative z-10"
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/Icon.tsx
+++ b/components/Icon.tsx
@@ -1,0 +1,80 @@
+import { SVGProps } from 'react'
+
+export type IconName =
+  | 'lotus'
+  | 'mind'
+  | 'sleep'
+  | 'focus'
+  | 'mobility'
+  | 'breath'
+  | 'spark'
+  | 'arrow-up-right'
+
+export default function Icon({ name, ...props }: { name: IconName } & SVGProps<SVGSVGElement>) {
+  switch (name) {
+    case 'lotus':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <path d="M12 3c-2 3-5 4-5 8a5 5 0 0 0 10 0c0-4-3-5-5-8z" />
+          <path d="M7 13c-2 1-3 2-3 4 0 2 2 4 8 4s8-2 8-4c0-2-1-3-3-4" />
+        </svg>
+      )
+    case 'mind':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <circle cx="12" cy="12" r="8" />
+          <path d="M12 8v4l2 2" />
+        </svg>
+      )
+    case 'sleep':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <path d="M6 14s1-4 6-4 6 4 6 4" />
+          <path d="M9 14v1" />
+          <path d="M15 14v1" />
+          <path d="M4 6h5L4 11h5" />
+        </svg>
+      )
+    case 'focus':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <circle cx="12" cy="12" r="3" />
+          <path d="M3 12h3M18 12h3M12 3v3M12 18v3" />
+        </svg>
+      )
+    case 'mobility':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <path d="M4 18l8-12 8 12" />
+          <path d="M12 15l-3 4h6l-3-4z" />
+        </svg>
+      )
+    case 'breath':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <path d="M3 12h6a4 4 0 0 1 4 4v5" />
+          <path d="M21 12h-6a4 4 0 0 0-4 4v5" />
+        </svg>
+      )
+    case 'spark':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <path d="M12 2v4" />
+          <path d="M12 18v4" />
+          <path d="M4.93 4.93l2.83 2.83" />
+          <path d="M16.24 16.24l2.83 2.83" />
+          <path d="M2 12h4" />
+          <path d="M18 12h4" />
+          <path d="M4.93 19.07l2.83-2.83" />
+          <path d="M16.24 7.76l2.83-2.83" />
+        </svg>
+      )
+    case 'arrow-up-right':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+          <path d="M7 17L17 7" />
+          <path d="M7 7h10v10" />
+        </svg>
+      )
+  }
+}

--- a/components/LiveOnDemand.tsx
+++ b/components/LiveOnDemand.tsx
@@ -1,0 +1,34 @@
+// Section: LiveOnDemand
+import Icon, { IconName } from './Icon'
+
+const categories: { icon: IconName; label: string }[] = [
+  { icon: 'spark', label: 'Energy' },
+  { icon: 'mind', label: 'Mind-Body' },
+  { icon: 'sleep', label: 'Sleep' },
+  { icon: 'breath', label: 'Breath' },
+  { icon: 'focus', label: 'Focus' },
+  { icon: 'mobility', label: 'Mobility' },
+]
+
+export default function LiveOnDemand() {
+  return (
+    <section className="bg-muted py-20" aria-labelledby="live-heading">
+      <div className="max-w-7xl mx-auto px-4 text-center">
+        <h2 id="live-heading" className="text-3xl font-bold">
+          Live &amp; On-Demand
+        </h2>
+        <p className="mt-4 max-w-2xl mx-auto text-gray-600">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </p>
+        <div className="mt-8 flex flex-wrap justify-center gap-6">
+          {categories.map((c) => (
+            <div key={c.label} className="flex w-20 flex-col items-center gap-2">
+              <Icon name={c.icon} className="h-9 w-9" />
+              <span className="text-xs">{c.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/TopStrip.tsx
+++ b/components/TopStrip.tsx
@@ -1,0 +1,21 @@
+// Section: TopStrip
+import Icon from './Icon'
+
+export default function TopStrip() {
+  return (
+    <div className="h-10 bg-muted">
+      <div className="max-w-7xl mx-auto h-full flex items-center justify-between px-4">
+        <div className="flex items-center gap-2 text-sm">
+          <Icon name="lotus" className="w-5 h-5" />
+          <span>MinuteZen</span>
+        </div>
+        <a
+          href="#"
+          className="text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
+        >
+          View Classes
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,13 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [{
+      protocol: 'https',
+      hostname: '**',
+    }],
+  },
+}
+
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "minute-zen",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.2.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        ink: 'var(--ink)',
+        muted: 'var(--muted)',
+        line: 'var(--line)',
+      },
+    },
+  },
+  plugins: [],
+}
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with Tailwind and TypeScript
- implement landing sections (Hero, Benefits, Courses, etc.)
- replace local images with remote placeholders to avoid binary assets

## Testing
- `npm install` *(fails: 403 Forbidden - autoprefixer)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc040416c8328be1abcc8532a9ea9