### PR TITLE
Document Next.js setup and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.env
+npm-debug.log
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# minute-zen
+# Minute Zen
+
+This project is built with [Next.js](https://nextjs.org/) and Tailwind CSS.
+
+## Getting Started
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Run lint checks:
+
+```bash
+npm run lint
+```
+
+Create a production build:
+
+```bash
+npm run build
+```
+

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "autoprefixer": "10.4.16",
     "postcss": "8.4.31",
     "tailwindcss": "3.3.3",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "@types/react": "^18.2.34",
+    "@types/node": "^20.10.5"
   }
 }


### PR DESCRIPTION
## Summary
- add .gitignore to exclude node modules and build output
- expand README with Next.js usage instructions
- declare TypeScript types for React and Node

## Testing
- `npm run lint` *(fails: missing required TypeScript dependencies)*
- `npm run build` *(fails: missing required TypeScript dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68ad7e78597c83289c199d1133d9e1a3