### PR TITLE
Use local image as hero background

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -6,10 +6,11 @@ export default function Hero() {
     <section className="relative overflow-hidden rounded-t-3xl" aria-labelledby="hero-heading">
       <div className="absolute inset-0">
         <Image
-          src="https://placehold.co/1200x800"
-          alt="Beach"
+          src="/minute%20zen.webp"
+          alt="Minute Zen"
           fill
           className="object-cover"
+          priority
         />
         <div className="absolute inset-0 bg-gradient-to-b from-blue-200/30" />
       </div>


### PR DESCRIPTION
## Summary
- Display local `minute zen.webp` file as the hero section background

## Testing
- `npm run lint` *(fails: Failed to install required TypeScript dependencies)*
- `npm install` *(fails: 403 Forbidden fetching @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68adaefe629c8328981a18c8c9975ddf