### PR TITLE
Replace placeholder meditation image

### DIFF
--- a/components/Benefits.tsx
+++ b/components/Benefits.tsx
@@ -31,7 +31,7 @@ export default function Benefits() {
               <span className="w-40 h-40 rounded-full bg-muted" />
             </span>
             <Image
-              src="https://placehold.co/200x200"
+              src="/meditation.png"
               alt="Meditation pose"
               width={200}
               height={200}


### PR DESCRIPTION
## Summary
- swap remote placeholder with local `public/meditation.png` image in benefits section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to install required TypeScript dependencies: @types/react @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68adb1ca2e3c832899eb8297eb00e168