### PR TITLE
feat: use logo as favicon

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,9 @@ export const metadata: Metadata = {
     title: 'MinuteZen — Harmony of Body, Peace of Mind',
     description: 'Daily yoga & meditation for body and mind.',
   },
+  icons: {
+    icon: '/minute-zen.webp',
+  },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- add site favicon referencing existing logo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68adb84068208328a62bdde2893487a1