### PR TITLE
Align left column benefit text to the right

### DIFF
--- a/components/Benefits.tsx
+++ b/components/Benefits.tsx
@@ -52,10 +52,10 @@ function BenefitItem({ icon, title, text, align }: { icon: IconName; title: stri
       <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-muted">
         <Icon name={icon} className="w-5 h-5" />
       </span>
-      <div>
-        <h3 className="font-medium">{title}</h3>
-        <p className="text-sm text-gray-600">{text}</p>
-      </div>
+        <div className={align === 'left' ? 'text-right' : undefined}>
+          <h3 className="font-medium">{title}</h3>
+          <p className="text-sm text-gray-600">{text}</p>
+        </div>
       {align === 'left' && (
         <span className="hidden lg:block absolute left-full top-5 w-8 border-t border-dashed border-line" />
       )}


### PR DESCRIPTION
## Summary
- right-align text and titles for left-side benefit items

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae068b41b083289464464deeffe9cb