### PR TITLE
Align benefit icons to right of text for first column

### DIFF
--- a/components/Benefits.tsx
+++ b/components/Benefits.tsx
@@ -49,13 +49,20 @@ function BenefitItem({ icon, title, text, align }: { icon: IconName; title: stri
       {align === 'right' && (
         <span className="hidden lg:block absolute right-full top-5 w-8 border-t border-dashed border-line" />
       )}
-      <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-muted">
-        <Icon name={icon} className="w-5 h-5" />
-      </span>
+      {align === 'right' && (
+        <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-muted">
+          <Icon name={icon} className="w-5 h-5" />
+        </span>
+      )}
       <div>
         <h3 className="font-medium">{title}</h3>
         <p className="text-sm text-gray-600">{text}</p>
       </div>
+      {align === 'left' && (
+        <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-muted">
+          <Icon name={icon} className="w-5 h-5" />
+        </span>
+      )}
       {align === 'left' && (
         <span className="hidden lg:block absolute left-full top-5 w-8 border-t border-dashed border-line" />
       )}


### PR DESCRIPTION
## Summary
- Render icons after text for left-column benefit items so icons appear to the right of their descriptions.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aea96c0b148328ad569663e7347994