### PR TITLE
feat: make footer year dynamic

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,6 +2,7 @@
 import Icon from './Icon'
 
 export default function Footer() {
+  const currentYear = new Date().getFullYear()
   return (
     <footer className="mt-20 border-t border-line" aria-labelledby="footer-heading">
       <h2 id="footer-heading" className="sr-only">
@@ -76,7 +77,7 @@ export default function Footer() {
             </li>
           </ul>
         </nav>
-        <p className="mt-2">© 2024 MinuteZen</p>
+        <p className="mt-2">© {currentYear} MinuteZen</p>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
- use `new Date().getFullYear()` for dynamic copyright year

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68af0bfe1a088328bcdfedad54f75f02