### PR TITLE
Replace placeholder text with French tagline

### DIFF
--- a/components/Courses.tsx
+++ b/components/Courses.tsx
@@ -4,22 +4,22 @@ import Image from 'next/image'
 const courses = [
   {
     title: 'Morning Flow',
-    text: 'Lorem ipsum dolor sit amet.',
+    text: 'Votre pause bien-être en 5 minutes, où que vous soyez.',
     img: '/nutrition & energie zen.webp',
   },
   {
     title: 'Evening Calm',
-    text: 'Lorem ipsum dolor sit amet.',
+    text: 'Votre pause bien-être en 5 minutes, où que vous soyez.',
     img: '/productivite & stress.webp',
   },
   {
     title: 'Mindful Breathing',
-    text: 'Lorem ipsum dolor sit amet.',
+    text: 'Votre pause bien-être en 5 minutes, où que vous soyez.',
     img: '/respiration & relaxation.webp',
   },
   {
     title: 'Deep Stretch',
-    text: 'Lorem ipsum dolor sit amet.',
+    text: 'Votre pause bien-être en 5 minutes, où que vous soyez.',
     img: '/yoga & mouvements rapides.webp',
   },
 ]

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
             <Icon name="lotus" className="h-6 w-6" />
             <span className="font-semibold">MinuteZen</span>
           </div>
-          <p className="mt-2 text-sm text-gray-600">Lorem ipsum dolor sit amet.</p>
+          <p className="mt-2 text-sm text-gray-600">Votre pause bien-être en 5 minutes, où que vous soyez.</p>
         </div>
         <div>
           <h3 className="font-medium">Quick Links</h3>


### PR DESCRIPTION
## Summary
- replace placeholder Lorem ipsum text with French tagline in footer and course cards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68af55c7edbc83289b18d92ef6bea967