### PR TITLE
feat: translate Live On-Demand heading

### DIFF
--- a/components/LiveOnDemand.tsx
+++ b/components/LiveOnDemand.tsx
@@ -15,7 +15,7 @@ export default function LiveOnDemand() {
     <section className="bg-muted py-20" aria-labelledby="live-heading">
       <div className="max-w-7xl mx-auto px-4 text-center">
         <h2 id="live-heading" className="text-3xl font-bold">
-          Live &amp; On-Demand
+          Vos pauses bien-être instantanées
         </h2>
         <p className="mt-4 max-w-2xl mx-auto text-gray-600">
           Faites une micro-séance de 3 à 5 minutes pour détendre le corps, calmer le mental et repartir concentré.


### PR DESCRIPTION
## Summary
- replace "Live & On-Demand" heading with "Vos pauses bien-être instantanées"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68af5fd81ecc8328892e730cb51da3d4