### PR TITLE
feat: translate live categories to French

### DIFF
--- a/components/LiveOnDemand.tsx
+++ b/components/LiveOnDemand.tsx
@@ -2,12 +2,12 @@
 import Icon, { IconName } from './Icon'
 
 const categories: { icon: IconName; label: string }[] = [
-  { icon: 'spark', label: 'Energy' },
-  { icon: 'mind', label: 'Mind-Body' },
-  { icon: 'sleep', label: 'Sleep' },
-  { icon: 'breath', label: 'Breath' },
-  { icon: 'focus', label: 'Focus' },
-  { icon: 'mobility', label: 'Mobility' },
+  { icon: 'spark', label: 'Énergie' },
+  { icon: 'mind', label: 'Corps & esprit' },
+  { icon: 'sleep', label: 'Sommeil' },
+  { icon: 'breath', label: 'Respiration' },
+  { icon: 'focus', label: 'Concentration' },
+  { icon: 'mobility', label: 'Mobilité' },
 ]
 
 export default function LiveOnDemand() {


### PR DESCRIPTION
## Summary
- update LiveOnDemand categories to French translations

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68af608b2d508328bcbca39b6683f3a9