### PR TITLE
feat: translate footer link heading

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -17,7 +17,7 @@ export default function Footer() {
           <p className="mt-2 text-sm text-gray-600">Votre pause bien-être en 5 minutes, où que vous soyez.</p>
         </div>
         <div>
-          <h3 className="font-medium">Quick Links</h3>
+          <h3 className="font-medium">Nos guides</h3>
           <ul className="mt-4 space-y-2 text-sm">
             {['Home', 'About', 'Courses', 'Pages', 'Blog', 'Contact'].map((link) => (
               <li key={link}>


### PR DESCRIPTION
## Summary
- localize Quick Links heading to French "Nos guides" in footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af68414e98832892b60aa62f827610