### PR TITLE
Add contact page and navigation link

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,24 @@
+import TopStrip from '../../components/TopStrip'
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+export const metadata = {
+  title: 'Contact – MinuteZen',
+}
+
+export default function Contact() {
+  return (
+    <>
+      <TopStrip />
+      <Header />
+      <main className="mx-auto max-w-3xl px-4 py-12 prose">
+        <h1>📬 Contact – MinuteZen</h1>
+        <p>Une question, une remarque ? N'hésitez pas à nous contacter :</p>
+        <ul>
+          <li>Email : <a href="mailto:contact@minutezen.fr">contact@minutezen.fr</a></li>
+        </ul>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -22,7 +22,7 @@ export default function Footer() {
             {['Home', 'About', 'Courses', 'Pages', 'Blog', 'Contact'].map((link) => (
               <li key={link}>
                 <a
-                  href="#"
+                  href={link === 'Contact' ? '/contact' : '#'}
                   className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
                 >
                   {link}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,7 +3,12 @@ import Link from 'next/link'
 import Icon from './Icon'
 
 export default function Header() {
-  const nav = ['Accueil', 'Ressources gratuites', 'Blog', 'Contact']
+  const nav = [
+    { name: 'Accueil', href: '/' },
+    { name: 'Ressources gratuites', href: '#' },
+    { name: 'Blog', href: '#' },
+    { name: 'Contact', href: '/contact' },
+  ]
   return (
     <header className="border-line">
       <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3 md:px-6">
@@ -14,11 +19,11 @@ export default function Header() {
         <nav className="hidden md:flex gap-6 text-sm">
           {nav.map((item) => (
             <Link
-              key={item}
-              href={item === 'Accueil' ? '/' : '#'}
+              key={item.name}
+              href={item.href}
               className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
             >
-              {item}
+              {item.name}
             </Link>
           ))}
         </nav>


### PR DESCRIPTION
## Summary
- add contact page with contact information
- link contact page from header and footer navigation

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af693bb7cc8328834048b47cf258d9