### PR TITLE
Add Ressources gratuites page and link CTA buttons

### DIFF
--- a/app/ressources-gratuites/page.tsx
+++ b/app/ressources-gratuites/page.tsx
@@ -1,0 +1,21 @@
+import TopStrip from '../../components/TopStrip'
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+export const metadata = {
+  title: 'Ressources gratuites – MinuteZen',
+}
+
+export default function RessourcesGratuites() {
+  return (
+    <>
+      <TopStrip />
+      <Header />
+      <main className="mx-auto max-w-3xl px-4 py-12 prose">
+        <h1>📚 Ressources gratuites – MinuteZen</h1>
+        <p>Découvrez prochainement notre sélection de ressources gratuites pour vous accompagner dans votre pratique.</p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/components/BottomCta.tsx
+++ b/components/BottomCta.tsx
@@ -13,7 +13,7 @@ export default function BottomCta() {
             </h2>
           </div>
           <a
-            href="#"
+            href="/ressources-gratuites"
             className="rounded-full bg-white px-6 py-3 text-sm text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             Découvrir les cours

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,7 @@ import Icon from './Icon'
 export default function Header() {
   const nav = [
     { name: 'Accueil', href: '/' },
-    { name: 'Ressources gratuites', href: '#' },
+    { name: 'Ressources gratuites', href: '/ressources-gratuites' },
     { name: 'Blog', href: '#' },
     { name: 'Contact', href: '/contact' },
   ]
@@ -30,7 +30,7 @@ export default function Header() {
         <div className="flex items-center gap-4">
           <span className="md:hidden text-sm">Menu</span>
           <a
-            href="#"
+            href="/ressources-gratuites"
             className="hidden md:inline-flex items-center gap-1 rounded-full border border-ink px-4 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
           >
             Découvrir les cours

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -27,7 +27,7 @@ export default function Hero() {
             Commencer
           </a>
           <a
-            href="#"
+            href="/ressources-gratuites"
             className="rounded-full px-6 py-3 text-sm text-white border border-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             Découvrir

--- a/components/TopStrip.tsx
+++ b/components/TopStrip.tsx
@@ -10,7 +10,7 @@ export default function TopStrip() {
           <span>MinuteZen</span>
         </div>
         <a
-          href="#"
+          href="/ressources-gratuites"
           className="text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
         >
           Découvrir les cours


### PR DESCRIPTION
## Summary
- add new Ressources gratuites page with placeholder content
- link all "Découvrir les cours" and "Ressources gratuites" buttons to the new page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68af6a6133708328a0f4f7687e2fe351