### PR TITLE
Remove placeholder navigation links from footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -18,18 +18,6 @@ export default function Footer() {
         </div>
         <div>
           <h3 className="font-medium">Nos guides</h3>
-          <ul className="mt-4 space-y-2 text-sm">
-            {['Home', 'About', 'Courses', 'Pages', 'Blog', 'Contact'].map((link) => (
-              <li key={link}>
-                <a
-                  href={link === 'Contact' ? '/contact' : '#'}
-                  className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
-                >
-                  {link}
-                </a>
-              </li>
-            ))}
-          </ul>
         </div>
         <div>
           <h3 className="font-medium">Newsletter</h3>


### PR DESCRIPTION
## Summary
- remove placeholder navigation links from the "Nos guides" footer section

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68af6e3b51808328b87d2b76c023fa55