### PR TITLE
Add blog index page showing DatoCMS articles

### DIFF
--- a/blog/index.tsx
+++ b/blog/index.tsx
@@ -1,0 +1,64 @@
+// pages/blog/index.tsx
+import { client } from '@/lib/datocms';
+import { ALL_ARTICLES_QUERY } from '@/lib/queries';
+import TopStrip from '@/components/TopStrip';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import Seo from '@/components/Seo';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { Article } from '@/lib/types';
+
+// We only need a subset of Article fields for the listing
+interface ArticleListItem extends Pick<Article, 'title' | 'slug' | 'lecture' | 'image'> {}
+
+export default function BlogIndex({ articles }: { articles: ArticleListItem[] }) {
+  return (
+    <>
+      <Seo tags={[]} titleFallback="Blog – MinuteZen" />
+      <TopStrip />
+      <Header />
+      <main className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="mb-8 text-3xl font-bold">Blog</h1>
+        <div className="grid gap-8 md:grid-cols-2">
+          {articles.map((article) => (
+            <article
+              key={article.slug}
+              className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+            >
+              {article.image?.responsiveImage && (
+                <Image
+                  src={article.image.responsiveImage.src}
+                  alt={article.image.responsiveImage.alt ?? article.title}
+                  width={article.image.responsiveImage.width}
+                  height={article.image.responsiveImage.height}
+                  sizes={article.image.responsiveImage.sizes}
+                  className="w-full"
+                />
+              )}
+              <div className="p-6">
+                <h2 className="text-xl font-semibold">
+                  <Link href={`/blog/${article.slug}`} className="hover:underline">
+                    {article.title}
+                  </Link>
+                </h2>
+                {typeof article.lecture === 'number' && (
+                  <p className="mt-2 text-sm text-slate-600">{article.lecture} min read</p>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  const { allArticles } = await client.request(ALL_ARTICLES_QUERY);
+  return {
+    props: { articles: allArticles },
+    revalidate: 60,
+  };
+}

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -65,3 +65,25 @@ export const ARTICLE_BY_SLUG_QUERY = /* GraphQL */ `
     }
   }
 `;
+
+export const ALL_ARTICLES_QUERY = /* GraphQL */ `
+  {
+    allArticles(orderBy: _firstPublishedAt_DESC) {
+      title
+      slug
+      lecture
+      image {
+        responsiveImage(imgixParams: { auto: format, fit: crop, w: 800, h: 400 }) {
+          src
+          srcSet
+          sizes
+          width
+          height
+          alt
+          title
+          base64
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add GraphQL query to retrieve all articles
- create blog index page that lists articles from DatoCMS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint? prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b0591225108328b113cb5a68f347a5