### PR TITLE
Add blog link to navigation menu

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,7 +6,7 @@ export default function Header() {
   const nav = [
     { name: 'Accueil', href: '/' },
     { name: 'Ressources gratuites', href: '/ressources-gratuites' },
-    { name: 'Blog', href: '#' },
+    { name: 'Blog', href: '/blog' },
     { name: 'Contact', href: '/contact' },
   ]
   return (


### PR DESCRIPTION
## Summary
- link the Blog page directly in the main header navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b05daa413483289af4176fc2b1f5cc