### PR TITLE
feat: fetch all blog posts via DatoCMS

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,5 @@
 // app/blog/page.tsx
-import { client } from '@/lib/datocms';
-import { ALL_ARTICLES_QUERY } from '@/lib/queries';
+import { getAllArticles } from '@/lib/datocms';
 import TopStrip from '@/components/TopStrip';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
@@ -15,8 +14,7 @@ interface ArticleListItem extends Pick<Article, 'title' | 'slug' | 'lecture' | '
 export const revalidate = 60;
 
 export default async function BlogIndex() {
-  const { allArticles } = await client.request(ALL_ARTICLES_QUERY);
-  const articles: ArticleListItem[] = allArticles;
+  const articles: ArticleListItem[] = await getAllArticles();
 
   return (
     <>

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -67,8 +67,8 @@ export const ARTICLE_BY_SLUG_QUERY = /* GraphQL */ `
 `;
 
 export const ALL_ARTICLES_QUERY = /* GraphQL */ `
-  {
-    allArticles(orderBy: _firstPublishedAt_DESC) {
+  query AllArticles($first: IntType, $skip: IntType) {
+    allArticles(first: $first, skip: $skip, orderBy: _firstPublishedAt_DESC) {
       title
       slug
       lecture


### PR DESCRIPTION
## Summary
- add query with pagination to load articles from DatoCMS
- add helper to retrieve all articles using `DATOCMS_API_TOKEN`
- use helper in blog index page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b0600e2f2083288971cc1d7838f7d5