### PR TITLE
fix datocms request body

### DIFF
--- a/lib/datocms.ts
+++ b/lib/datocms.ts
@@ -28,6 +28,7 @@ export async function datoRequest<T = any>(
       'X-Exclude-Invalid': 'true',
       ...(process.env.DATOCMS_INCLUDE_DRAFTS === 'true' ? { 'X-Include-Drafts': 'true' } : {}),
     },
+    body: JSON.stringify({ query, variables }),
     // en debug, évite le cache build-time
     cache: 'no-store',
     // si tu utilises l'Edge runtime, commente le suivant


### PR DESCRIPTION
## Summary
- include JSON GraphQL body in DatoCMS fetch requests

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `DATOCMS_API_TOKEN=dummy npm run build` *(fails: fetch ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b0abca99c88328af9674fd425539f3