### PR TITLE
fix: provide local fallback data for blog articles

### DIFF
--- a/lib/datocms.ts
+++ b/lib/datocms.ts
@@ -1,12 +1,24 @@
 // lib/datocms.ts
 import 'server-only';
-import { ALL_ARTICLES_QUERY } from './queries';
+import { ALL_ARTICLES_QUERY, ARTICLE_BY_SLUG_QUERY, ARTICLE_SLUGS_QUERY } from './queries';
 import type { Article } from './types';
 
 const TOKEN = process.env.DATOCMS_API_TOKEN; // même nom que sur Vercel
-if (!TOKEN) {
-  throw new Error('❌ DATOCMS_API_TOKEN manquant (Vercel > Settings > Environment Variables).');
-}
+
+// Petit jeu de données local utilisé quand le token DatoCMS n'est pas défini.
+// Cela permet de faire tourner le site (et les tests) sans accès à l'API distante.
+const FALLBACK_ARTICLES: Article[] = [
+  {
+    title: 'Test du titre',
+    slug: 'test-du-titre',
+    lecture: 1,
+    seo: [],
+    image: null,
+    auteur: { name: 'John Doe' },
+    content: { value: { document: 'Contenu de test' } },
+    faq: [],
+  },
+];
 
 // Passe en preview si tu veux voir les brouillons (ou mets DATOCMS_INCLUDE_DRAFTS=true)
 const ENDPOINT =
@@ -20,6 +32,21 @@ export async function datoRequest<T = any>(
   query: string,
   variables?: Record<string, unknown>
 ): Promise<T> {
+  // Sans token on renvoie les données factices ci-dessus.
+  if (!TOKEN) {
+    if (query === ARTICLE_SLUGS_QUERY) {
+      return { allArticles: FALLBACK_ARTICLES.map((a) => ({ slug: a.slug })) } as T;
+    }
+    if (query === ARTICLE_BY_SLUG_QUERY) {
+      const article = FALLBACK_ARTICLES.find((a) => a.slug === variables?.slug);
+      return { article } as T;
+    }
+    if (query === ALL_ARTICLES_QUERY) {
+      return { allArticles: FALLBACK_ARTICLES } as T;
+    }
+    throw new Error('❌ DATOCMS_API_TOKEN manquant et requête non supportée.');
+  }
+
   const res = await fetch(ENDPOINT, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- avoid crash when DATOCMS_API_TOKEN is missing
- serve a mock article for `/blog/test-du-titre`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_68b0af4dbc988328b9179aeb5939a265