### PR TITLE
Add wildcard pathname for remote images

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: '**',
+        pathname: '**',
       },
     ],
   },


### PR DESCRIPTION
## Summary
- allow `next/image` to load remote images from any path

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68b0b330e8d48328af50c216f70c54b1