### PR TITLE
Fix missing article slugs causing blog link failures

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -12,7 +12,9 @@ export const revalidate = 60;
 
 export async function generateStaticParams() {
   const data = await client.request(ARTICLE_SLUGS_QUERY);
-  return data.allArticles.map((a: { slug: string }) => ({ slug: a.slug }));
+  return data.allArticles
+    .filter((a: { slug?: string | null }) => a.slug)
+    .map((a: { slug: string }) => ({ slug: a.slug }));
 }
 
 export default async function ArticlePage({ params }: { params: { slug: string } }) {

--- a/lib/datocms.ts
+++ b/lib/datocms.ts
@@ -91,7 +91,8 @@ export async function getAllArticles(): Promise<Pick<Article, 'title' | 'slug' |
       ALL_ARTICLES_QUERY,
       { first: PAGE_SIZE, skip }
     );
-    all.push(...allArticles);
+    // Filter out entries without a valid slug to avoid broken links
+    all.push(...allArticles.filter((a) => a.slug));
     if (allArticles.length < PAGE_SIZE) {
       break;
     }


### PR DESCRIPTION
## Summary
- Skip articles without a slug when generating blog list from DatoCMS
- Ignore entries lacking a slug when generating static article routes

## Testing
- `npm run build`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b625dfc883288f15d7afa0d10408