### PR TITLE
Fix article query exports and add DatoCMS helper

### DIFF
--- a/lib/datocms.ts
+++ b/lib/datocms.ts
@@ -1,5 +1,7 @@
 // lib/datocms.ts
 import 'server-only';
+import type { Article } from './types';
+import { ALL_ARTICLES_QUERY } from './queries';
 
 const endpoint = process.env.DATOCMS_GRAPHQL_ENDPOINT ?? 'https://graphql.datocms.com/';
 const token = process.env.DATOCMS_API_TOKEN;
@@ -51,4 +53,9 @@ export async function datoRequest<T>(
   }
 
   return json.data as T;
+}
+
+export async function getAllArticles(): Promise<Article[]> {
+  const { allArticles } = await datoRequest<{ allArticles: Article[] }>(ALL_ARTICLES_QUERY);
+  return allArticles;
 }

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -87,3 +87,7 @@ export const ALL_ARTICLES_QUERY = /* GraphQL */ `
     }
   }
 `;
+
+// Alias exports to match the names used throughout the app
+export const ALL_SLUGS = ARTICLE_SLUGS_QUERY;
+export const ARTICLE_BY_SLUG = ARTICLE_BY_SLUG_QUERY;


### PR DESCRIPTION
## Summary
- add alias exports for article queries to match expected names
- implement `getAllArticles` helper using existing DatoCMS request utility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Missing DATOCMS_API_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad1693088328966e69a98387de50