### PR TITLE
feat: improve DatoCMS error logging

### DIFF
--- a/lib/datocms.ts
+++ b/lib/datocms.ts
@@ -17,6 +17,7 @@ export async function datoRequest<T>(
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    Accept: 'application/json',
     Authorization: `Bearer ${token}`,
     'X-Exclude-Invalid': 'true', // évite les records invalides
   };
@@ -37,8 +38,12 @@ export async function datoRequest<T>(
   try {
     json = JSON.parse(text);
   } catch {
-    console.error('DatoCMS non-JSON response:', { status: res.status, text });
-    throw new Error(`DatoCMS response not JSON (status ${res.status}).`);
+    console.error('DatoCMS non-JSON response:', {
+      status: res.status,
+      statusText: res.statusText,
+      text,
+    });
+    throw new Error(`DatoCMS response not JSON (status ${res.status} ${res.statusText}).`);
   }
 
   if (!res.ok || json.errors) {


### PR DESCRIPTION
## Summary
- request JSON explicitly from DatoCMS
- expand non-JSON error logging with status text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aecf32108328b4a3b1166d8091a5