### PR TITLE
Handle DatoCMS fetch errors by returning 404

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -50,9 +50,11 @@ export default async function Page({ params }: { params: { slug: string } }) {
       { slug: params.slug, locale: LOCALE }
     ));
   } catch (e) {
-    // NE PAS transformer l'erreur en 404: on log et on relance pour voir l'erreur réelle en logs
+    // En cas d'erreur de récupération (ex. DatoCMS indisponible),
+    // on journalise l'erreur mais on renvoie une 404 pour éviter
+    // de faire tomber l'application avec une 500.
     console.error('article fetch error', e);
-    throw e;
+    notFound();
   }
 
   if (!article) {


### PR DESCRIPTION
## Summary
- avoid crashing the article page when DatoCMS requests fail by logging the error and returning a 404

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1ebb888bc83289eb0f36ac9458243