### PR TITLE
Render DatoCMS articles on blog

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,14 @@ import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import { datoRequest } from '@/lib/datocms';
 import { ALL_SLUGS, ARTICLE_BY_SLUG } from '@/lib/queries';
+import type { Article } from '@/lib/types';
+import TopStrip from '@/components/TopStrip';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import Seo from '@/components/Seo';
+import ArticleContent from '@/components/ArticleContent';
+import AuthorBio from '@/components/AuthorBio';
+import FaqBlock from '@/components/FaqBlock';
 
 export const runtime = 'nodejs';
 export const revalidate = 60;
@@ -43,10 +51,10 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {
-  let article: any;
+  let article: Article | null = null;
 
   try {
-    ({ article } = await datoRequest<{ article: any }>(
+    ({ article } = await datoRequest<{ article: Article }>(
       ARTICLE_BY_SLUG,
       { slug: params.slug, locale: LOCALE }
     ));
@@ -64,18 +72,29 @@ export default async function Page({ params }: { params: { slug: string } }) {
   }
 
   return (
-    <main className="prose mx-auto">
-      <h1>{article.title}</h1>
-      {article.image?.responsiveImage && (
-        <Image
-          src={article.image.responsiveImage.src}
-          alt={article.image.responsiveImage.alt ?? article.title}
-          width={article.image.responsiveImage.width}
-          height={article.image.responsiveImage.height}
-          sizes={article.image.responsiveImage.sizes}
-        />
-      )}
-      {/* StructuredText ici si besoin */}
-    </main>
+    <>
+      <Seo tags={article.seo} titleFallback={article.title} />
+      <TopStrip />
+      <Header />
+      <main className="mx-auto max-w-3xl px-4 py-16">
+        <h1 className="mb-6 text-3xl font-bold">{article.title}</h1>
+        {article.image?.responsiveImage && (
+          <Image
+            src={article.image.responsiveImage.src}
+            alt={article.image.responsiveImage.alt ?? article.title}
+            width={article.image.responsiveImage.width}
+            height={article.image.responsiveImage.height}
+            sizes={article.image.responsiveImage.sizes}
+            className="mb-8 w-full"
+          />
+        )}
+        <ArticleContent article={article} />
+        {article.auteur && <AuthorBio author={article.auteur} />}
+        {article.faq?.map(f => (
+          <FaqBlock key={f.id} item={f} />
+        ))}
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/components/ArticleContent.tsx
+++ b/components/ArticleContent.tsx
@@ -1,8 +1,20 @@
 // components/ArticleContent.tsx
 import type { Article } from '@/lib/types';
+import { renderStructuredText } from '@/lib/renderStructuredText';
+import FaqBlock from './FaqBlock';
 
 export default function ArticleContent({ article }: { article: Article }) {
-  // Rendering of structured content from DatoCMS is not available without external dependencies.
-  // For now, output the raw JSON for debugging purposes.
-  return <pre className="whitespace-pre-wrap">{JSON.stringify(article.content?.value, null, 2)}</pre>;
+  return (
+    <div className="prose">
+      {renderStructuredText(article.content.value, {
+        blocks: article.content.blocks,
+        renderBlock: (block) => {
+          if (block.__typename === 'FaqRecord') {
+            return <FaqBlock item={block} />;
+          }
+          return null;
+        },
+      })}
+    </div>
+  );
 }

--- a/components/FaqBlock.tsx
+++ b/components/FaqBlock.tsx
@@ -1,13 +1,12 @@
 // components/FaqBlock.tsx
 import type { FaqBlock } from '@/lib/types';
+import { renderStructuredText } from '@/lib/renderStructuredText';
 
 export default function FaqBlock({ item }: { item: FaqBlock }) {
   return (
     <div className="rounded-2xl border p-4 my-6">
       <h3 className="text-lg font-semibold mb-2">{item.question}</h3>
-      <div className="prose whitespace-pre-wrap">
-        {JSON.stringify(item.reponse?.value, null, 2)}
-      </div>
+      <div className="prose">{renderStructuredText(item.reponse?.value)}</div>
     </div>
   );
 }

--- a/lib/renderStructuredText.tsx
+++ b/lib/renderStructuredText.tsx
@@ -1,0 +1,62 @@
+import React, { Fragment } from 'react';
+
+export type StructuredTextValue = {
+  document: any;
+};
+
+interface RenderOptions {
+  blocks?: any[];
+  renderBlock?: (block: any) => React.ReactNode;
+}
+
+function renderNode(
+  node: any,
+  index: number,
+  options: RenderOptions
+): React.ReactNode {
+  switch (node.type) {
+    case 'root':
+      return <Fragment key={index}>{node.children?.map((n: any, i: number) => renderNode(n, i, options))}</Fragment>;
+    case 'paragraph':
+      return <p key={index}>{node.children?.map((n: any, i: number) => renderNode(n, i, options))}</p>;
+    case 'heading': {
+      const Tag = `h${node.level}` as keyof JSX.IntrinsicElements;
+      return <Tag key={index}>{node.children?.map((n: any, i: number) => renderNode(n, i, options))}</Tag>;
+    }
+    case 'list': {
+      const ListTag = node.style === 'unordered' ? 'ul' : 'ol';
+      return <ListTag key={index}>{node.children?.map((n: any, i: number) => renderNode(n, i, options))}</ListTag>;
+    }
+    case 'listItem':
+      return <li key={index}>{node.children?.map((n: any, i: number) => renderNode(n, i, options))}</li>;
+    case 'blockquote':
+      return <blockquote key={index}>{node.children?.map((n: any, i: number) => renderNode(n, i, options))}</blockquote>;
+    case 'link':
+      return (
+        <a key={index} href={node.url}>
+          {node.children?.map((n: any, i: number) => renderNode(n, i, options))}
+        </a>
+      );
+    case 'span':
+      return node.value;
+    case 'block': {
+      const block = options.blocks?.find((b: any) => b.id === node.id);
+      if (block && options.renderBlock) {
+        return <Fragment key={index}>{options.renderBlock(block)}</Fragment>;
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function renderStructuredText(
+  value: StructuredTextValue | null | undefined,
+  options: RenderOptions = {}
+): React.ReactNode {
+  if (!value?.document) return null;
+  return renderNode(value.document, 0, options);
+}
+
+export default renderStructuredText;


### PR DESCRIPTION
## Summary
- render structured article content from DatoCMS
- add author and FAQ blocks on article pages
- introduce minimal StructuredText renderer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Next.js prompt to configure ESLint)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b215956efc8328ba87bd6e42231341