### PR TITLE
Fix article 404 by fetching blog posts with locale

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -13,10 +13,12 @@ interface ArticleListItem extends Pick<Article, 'title' | 'slug' | 'lecture' | '
 
 export const revalidate = 60;
 
+const LOCALE = process.env.DEFAULT_LOCALE || 'fr';
+
 export default async function BlogIndex() {
   let articles: ArticleListItem[] = [];
   try {
-    articles = await getAllArticles();
+    articles = await getAllArticles(LOCALE);
   } catch (e) {
     console.error('getAllArticles error', e);
   }

--- a/lib/datocms.ts
+++ b/lib/datocms.ts
@@ -60,7 +60,12 @@ export async function datoRequest<T>(
   return json.data as T;
 }
 
-export async function getAllArticles(): Promise<Article[]> {
-  const { allArticles } = await datoRequest<{ allArticles: Article[] }>(ALL_ARTICLES_QUERY);
+export async function getAllArticles(
+  locale: string = process.env.DEFAULT_LOCALE || 'fr'
+): Promise<Article[]> {
+  const { allArticles } = await datoRequest<{ allArticles: Article[] }>(
+    ALL_ARTICLES_QUERY,
+    { locale }
+  );
   return allArticles;
 }


### PR DESCRIPTION
## Summary
- ensure Datocms article list uses the same locale as detail pages
- add locale constant to blog index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive ESLint configuration)*
- `npm run build` *(fails: Missing DATOCMS_API_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68b2180155fc83288b50df7f5f650d44