### PR TITLE
Prefetch blog article links

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -48,7 +48,7 @@ export default async function BlogIndex() {
               )}
               <div className="p-6">
                 <h2 className="text-xl font-semibold">
-                  <Link href={`/blog/${article.slug}`} className="hover:underline">
+                  <Link href={`/blog/${article.slug}`} prefetch className="hover:underline">
                     {article.title}
                   </Link>
                 </h2>


### PR DESCRIPTION
## Summary
- enable prefetching on blog article links
- confirm no rewrites for `/blog/:slug`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b21d0d92e0832899b8f47d1d3d524c