### PR TITLE
Handle DatoCMS errors gracefully on article pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -23,11 +23,16 @@ export async function generateStaticParams() {
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {
-  // Ne pas transformer une erreur en 404 : on laisse remonter pour logs clairs
-  const { article } = await datoRequest<{ article: any }>(
-    ARTICLE_BY_SLUG,
-    { slug: params.slug, locale: LOCALE }
-  );
+  let article: any = null;
+  try {
+    ({ article } = await datoRequest<{ article: any }>(
+      ARTICLE_BY_SLUG,
+      { slug: params.slug, locale: LOCALE }
+    ));
+  } catch (e) {
+    console.error('ARTICLE_BY_SLUG error', e);
+    notFound();
+  }
 
   if (!article) {
     console.error('Article introuvable', { slug: params.slug, localeTried: LOCALE });


### PR DESCRIPTION
## Summary
- prevent article page build from failing when DatoCMS returns errors

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b22af4c3188328a9eee1c0cad4a31d