### PR TITLE
Add react-datocms dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-datocms": "^1.0.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",


### PR DESCRIPTION
## Summary
- add missing `react-datocms` dependency used for structured text rendering

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run build` *(fails: Module not found: Can't resolve 'react-datocms/structured-text' because dependency installation requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cfabe9648328bc4fc5b8bf95e5ff