### PR TITLE
Replace react-datocms StructuredText with internal component

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@
 import { notFound } from 'next/navigation';
 import { datoRequest } from '@/lib/datocms';
 import { ALL_SLUGS, ARTICLE_BY_SLUG } from '@/lib/queries';
-import { StructuredText } from 'react-datocms/structured-text';
+import StructuredText from '@/components/StructuredText';
 export const runtime = 'nodejs';
 export const revalidate = 60;
 // Utile si un parent a mis dynamicParams = false

--- a/components/StructuredText.tsx
+++ b/components/StructuredText.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+type StructuredTextNode = {
+  type: string;
+  value?: string;
+  children?: StructuredTextNode[];
+};
+
+interface StructuredTextProps {
+  data: {
+    value?: {
+      document?: StructuredTextNode;
+    };
+  } | null;
+}
+
+function renderNode(node: StructuredTextNode, key: number): React.ReactNode {
+  switch (node.type) {
+    case 'paragraph':
+      return <p key={key}>{node.children?.map((child, i) => renderNode(child, i))}</p>;
+    case 'span':
+      return node.value ?? null;
+    default:
+      return node.children?.map((child, i) => renderNode(child, i));
+  }
+}
+
+export default function StructuredText({ data }: StructuredTextProps) {
+  const document = data?.value?.document;
+  if (!document) return null;
+  return <>{document.children?.map((node, i) => renderNode(node, i))}</>;
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-datocms": "^1.0.0"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",


### PR DESCRIPTION
## Summary
- Replace blog page's dependency on `react-datocms` with a local `StructuredText` renderer
- Remove unused `react-datocms` package from dependencies
- Add lightweight `StructuredText` component to handle basic paragraph and span rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: configuration prompt prevented non-interactive run)*
- `npm run build` *(fails: Missing DATOCMS_API_TOKEN at runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d188de548328b7371b65920792f0