### PR TITLE
Add react-datocms dependency for blog structured text

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@
 import { notFound } from 'next/navigation';
 import { datoRequest } from '@/lib/datocms';
 import { ALL_SLUGS, ARTICLE_BY_SLUG } from '@/lib/queries';
-import { StructuredText } from 'react-datocms/structured-text';
+import { StructuredText } from 'react-datocms';
 
 export const runtime = 'nodejs';
 export const revalidate = 60;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-datocms": "^1.0.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",


### PR DESCRIPTION
## Summary
- fix blog build by depending on `react-datocms`
- update blog slug page to import `StructuredText` from the new dependency

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'react-datocms')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2da783aac832891884392d66bed83