### PR TITLE
feat: handle marks in structured text

### DIFF
--- a/lib/renderStructuredText.tsx
+++ b/lib/renderStructuredText.tsx
@@ -37,8 +37,19 @@ function renderNode(
           {node.children?.map((n: any, i: number) => renderNode(n, i, options))}
         </a>
       );
-    case 'span':
-      return node.value;
+    case 'span': {
+      let content: React.ReactNode = node.value;
+      if (node.marks) {
+        node.marks.forEach((mark: string) => {
+          if (mark === 'strong') {
+            content = <strong>{content}</strong>;
+          } else if (mark === 'em') {
+            content = <em>{content}</em>;
+          }
+        });
+      }
+      return <Fragment key={index}>{content}</Fragment>;
+    }
     case 'block': {
       const block = options.blocks?.find((b: any) => b.id === node.id);
       if (block && options.renderBlock) {


### PR DESCRIPTION
## Summary
- support bold and italic marks when rendering Structured Text content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive setup prompt)*
- `npm run build` *(fails: Missing DATOCMS_API_TOKEN at runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b31391c36483289009ea3e7d05558b