### PR TITLE
Reduce article image height

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -150,7 +150,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
               src={rimg.src}
               alt={rimg.alt ?? ''}
               width={rimg.width}
-              height={rimg.height}
+              height={rimg.height / 2}
               sizes="(max-width: 768px) 100vw, 768px"
               className="h-auto w-full"
             />

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -41,7 +41,7 @@ export default async function BlogIndex() {
                   src={article.image.responsiveImage.src}
                   alt={article.image.responsiveImage.alt ?? article.title}
                   width={article.image.responsiveImage.width}
-                  height={article.image.responsiveImage.height}
+                  height={article.image.responsiveImage.height / 2}
                   sizes={article.image.responsiveImage.sizes}
                   className="w-full"
                 />


### PR DESCRIPTION
## Summary
- Halve the rendered height of article images in both blog list and detail pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive ESLint configuration prompt)

------
https://chatgpt.com/codex/tasks/task_e_68b3149ec9588328a802511fddebbca5