### PR TITLE
Halve article cover image height

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -124,7 +124,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
               src={rimg.src}
               alt={rimg.alt ?? ''}
               width={rimg.width}
-              height={rimg.height}
+              height={rimg.height / 2}
               sizes="(max-width: 768px) 100vw, 768px"
               className="h-auto w-full"
             />


### PR DESCRIPTION
## Summary
- reduce blog article cover image height by half for better balance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b31ad056488328a42f0f9f152b8554