### PR TITLE
Fix image height styling

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -191,8 +191,6 @@ export default async function Page({ params }: { params: { slug: string } }) {
               <img
                 src={auteur.imageauteur.url}
                 alt={auteur.imageauteur.alt ?? auteur.nom ?? 'Auteur'}
-                width={56}
-                height={56}
                 className="h-14 w-14 rounded-full object-cover ring-2 ring-emerald-100"
               />
             )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,3 +11,8 @@
 body {
   @apply antialiased text-gray-800 bg-white;
 }
+
+img {
+  height: 300px;
+  width: auto;
+}


### PR DESCRIPTION
## Summary
- globally enforce 300px height for images with auto width
- allow blog author avatars to be styled via CSS by removing fixed width/height attributes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: waiting for interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b31c24f38c8328ace8311de2db1d16