### PR TITLE
Ensure integer heights for article images

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -124,7 +124,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
               src={rimg.src}
               alt={rimg.alt ?? ''}
               width={rimg.width}
-              height={rimg.height / 2}
+              height={Math.round(rimg.height / 2)}
               sizes="(max-width: 768px) 100vw, 768px"
               className="h-auto w-full"
             />

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -41,7 +41,7 @@ export default async function BlogIndex() {
                   src={article.image.responsiveImage.src}
                   alt={article.image.responsiveImage.alt ?? article.title}
                   width={article.image.responsiveImage.width}
-                  height={article.image.responsiveImage.height / 2}
+                  height={Math.round(article.image.responsiveImage.height / 2)}
                   sizes={article.image.responsiveImage.sizes}
                   className="w-full"
                 />


### PR DESCRIPTION
## Summary
- Round article cover image height to keep half-size as integer
- Round blog index image height to maintain consistent aspect ratio

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68b31f3a1b008328bd57f890cb30e82c