### PR TITLE
Crop blog images to half height

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -119,14 +119,17 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
         {/* Image de couverture */}
         {rimg?.src && (
-          <div className="my-6 overflow-hidden rounded-2xl ring-1 ring-emerald-100 shadow">
+          <div
+            className="my-6 overflow-hidden rounded-2xl ring-1 ring-emerald-100 shadow"
+            style={{ height: Math.round(rimg.height / 2) }}
+          >
             <Image
               src={rimg.src}
               alt={rimg.alt ?? ''}
               width={rimg.width}
-              height={Math.round(rimg.height / 2)}
+              height={rimg.height}
               sizes="(max-width: 768px) 100vw, 768px"
-              className="h-auto w-full"
+              className="h-full w-full object-cover"
             />
           </div>
         )}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -37,14 +37,19 @@ export default async function BlogIndex() {
               className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
             >
               {article.image?.responsiveImage && (
-                <Image
-                  src={article.image.responsiveImage.src}
-                  alt={article.image.responsiveImage.alt ?? article.title}
-                  width={article.image.responsiveImage.width}
-                  height={Math.round(article.image.responsiveImage.height / 2)}
-                  sizes={article.image.responsiveImage.sizes}
-                  className="w-full"
-                />
+                <div
+                  style={{ height: Math.round(article.image.responsiveImage.height / 2) }}
+                  className="overflow-hidden"
+                >
+                  <Image
+                    src={article.image.responsiveImage.src}
+                    alt={article.image.responsiveImage.alt ?? article.title}
+                    width={article.image.responsiveImage.width}
+                    height={article.image.responsiveImage.height}
+                    sizes={article.image.responsiveImage.sizes}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
               )}
               <div className="p-6">
                 <h2 className="text-xl font-semibold">


### PR DESCRIPTION
## Summary
- crop blog list images to half height by wrapping Image in fixed-height container
- crop article cover images to half height with object-cover styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint configuration prompt)*
- `npm run build` *(fails: Cannot find module '@tailwindcss/typography')*


------
https://chatgpt.com/codex/tasks/task_e_68b3211cede88328a2f77a1f5765fab4