### PR TITLE
feat: add Pack Audio landing page

### DIFF
--- a/app/pack-audio/page.tsx
+++ b/app/pack-audio/page.tsx
@@ -1,0 +1,57 @@
+import TopStrip from '../../components/TopStrip'
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+import Image from 'next/image'
+import DownloadForm from '../../components/DownloadForm'
+
+export const metadata = {
+  title: 'Pack Audio MinuteZen – MinuteZen',
+}
+
+export default function PackAudio() {
+  return (
+    <>
+      <TopStrip />
+      <Header />
+      <main className="mx-auto max-w-3xl px-4 py-16">
+        <section className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900">
+            Calme ton esprit en 5 minutes – Télécharge gratuitement ton Pack Audio MinuteZen
+          </h1>
+          <p className="mt-4 text-gray-600">
+            Stress, fatigue, pensées qui tournent en boucle ? Avec ce pack gratuit de 5 audios guidés, découvre des exercices simples et efficaces pour retrouver ton calme, libérer les tensions et recharger ton énergie… en seulement quelques minutes par jour.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <Image src="/pack-audio-mockup.svg" alt="Pack Audio MinuteZen" width={240} height={240} />
+          </div>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-2xl font-semibold text-gray-900">Ce que tu vas recevoir</h2>
+          <ul className="mt-6 space-y-3 text-gray-700">
+            <li>🎧 Respiration anti-stress express – pour apaiser ton esprit immédiatement</li>
+            <li>🎧 Relâcher les épaules et la nuque – fini les tensions physiques accumulées</li>
+            <li>🎧 Micro-visualisation positive – retrouver confiance et clarté mentale</li>
+            <li>🎧 Pause énergie au bureau – recharge rapide pour éviter le coup de fatigue</li>
+            <li>🎧 Endormissement rapide – glisser vers un sommeil profond et réparateur</li>
+          </ul>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-2xl font-semibold text-gray-900">Télécharge ton Pack Audio MinuteZen gratuitement</h2>
+          <DownloadForm />
+        </section>
+
+        <section className="mt-12">
+          <ul className="space-y-3 text-gray-700">
+            <li>⏱️ Des pauses courtes, 4–5 minutes seulement</li>
+            <li>🎧 Faciles à écouter partout : téléphone, bureau, lit</li>
+            <li>💡 Techniques validées par la science de la respiration et de la relaxation</li>
+            <li>🧘 Pas de bla-bla, juste l’essentiel pour retrouver ton équilibre</li>
+          </ul>
+        </section>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/components/DownloadForm.tsx
+++ b/components/DownloadForm.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+export default function DownloadForm() {
+  return (
+    <form
+      className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2"
+      onSubmit={(e) => {
+        e.preventDefault()
+        const data = new FormData(e.currentTarget)
+        const name = data.get('name') as string
+        const email = data.get('email') as string
+        const mailto = `mailto:contact@minutezen.fr?subject=${encodeURIComponent('Pack Audio MinuteZen')}&body=${encodeURIComponent(`Prénom: ${name}\nEmail: ${email}`)}`
+        window.location.href = mailto
+      }}
+    >
+      <div>
+        <label className="block text-sm font-medium text-slate-800">Prénom</label>
+        <input
+          name="name"
+          type="text"
+          required
+          className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus:border-blue-400"
+          placeholder="Ton prénom"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-800">Email</label>
+        <input
+          name="email"
+          type="email"
+          required
+          className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus:border-blue-400"
+          placeholder="toi@exemple.com"
+        />
+      </div>
+      <div className="sm:col-span-2">
+        <button
+          type="submit"
+          className="mt-2 w-full rounded-full bg-slate-900 px-5 py-3 text-sm font-medium text-white hover:bg-slate-800"
+        >
+          Oui, je veux mes 5 audios gratuits
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/public/pack-audio-mockup.svg
+++ b/public/pack-audio-mockup.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+  <rect x="70" y="20" width="100" height="200" rx="12" ry="12" fill="white" stroke="#1f2937" stroke-width="4"/>
+  <rect x="85" y="40" width="70" height="130" fill="#f3f4f6"/>
+  <circle cx="120" cy="180" r="8" fill="#1f2937"/>
+  <circle cx="40" cy="110" r="15" fill="white" stroke="#1f2937" stroke-width="4"/>
+  <circle cx="200" cy="110" r="15" fill="white" stroke="#1f2937" stroke-width="4"/>
+  <path d="M55 110 C70 60, 170 60, 185 110" fill="none" stroke="#1f2937" stroke-width="4"/>
+  <text x="120" y="225" font-size="16" text-anchor="middle" fill="#1f2937">Pack Audio MinuteZen</text>
+</svg>


### PR DESCRIPTION
## Summary
- create Pack Audio landing page with hero, audio list, download form and reassurance section
- add client-side form component to collect name and email
- include simple SVG mockup asset for the audio pack

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build` *(fails: Missing DATOCMS_API_TOKEN / fetch failed during export)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ffa96c108328b45259803fd85e19