### PR TITLE
Link CTA buttons to pack-audio page

### DIFF
--- a/components/BottomCta.tsx
+++ b/components/BottomCta.tsx
@@ -13,7 +13,7 @@ export default function BottomCta() {
             </h2>
           </div>
           <a
-            href="/ressources-gratuites"
+            href="/pack-audio"
             className="rounded-full bg-white px-6 py-3 text-sm text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             Découvrir les cours

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
         <div className="flex items-center gap-4">
           <span className="md:hidden text-sm">Menu</span>
           <a
-            href="/ressources-gratuites"
+            href="/pack-audio"
             className="hidden md:inline-flex items-center gap-1 rounded-full border border-ink px-4 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
           >
             Découvrir les cours

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -21,13 +21,13 @@ export default function Hero() {
         <p className="max-w-md text-sm md:text-base text-white drop-shadow-md">Faites une micro-séance de 3 à 5 minutes pour détendre le corps, calmer le mental et repartir concentré.</p>
         <div className="flex gap-4">
           <a
-            href="#"
+            href="/pack-audio"
             className="rounded-full bg-white text-black px-6 py-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black"
           >
             Commencer
           </a>
           <a
-            href="/ressources-gratuites"
+            href="/pack-audio"
             className="rounded-full px-6 py-3 text-sm text-white border border-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
           >
             Découvrir

--- a/components/TopStrip.tsx
+++ b/components/TopStrip.tsx
@@ -10,7 +10,7 @@ export default function TopStrip() {
           <span>MinuteZen</span>
         </div>
         <a
-          href="/ressources-gratuites"
+          href="/pack-audio"
           className="text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink"
         >
           Découvrir les cours


### PR DESCRIPTION
## Summary
- Point header CTA link to `/pack-audio`
- Route hero section buttons to the audio pack page
- Update top strip and bottom CTA links to `/pack-audio`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b4846c1fe88328a0f17d97831efc28