### PR TITLE
Send email from contact form

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const { name, email, subject, message } = await request.json()
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+    },
+    body: JSON.stringify({
+      from: 'Contact Form <onboarding@resend.dev>',
+      to: ['contact@minutezen.fr'],
+      subject: subject || 'Message MinuteZen',
+      reply_to: email,
+      text: `Nom: ${name}\nEmail: ${email}\n\n${message}`,
+    }),
+  })
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Failed to send email' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,26 +1,37 @@
 "use client"
 
+import { useState } from 'react'
 import Link from 'next/link'
 
 export default function ContactForm() {
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState(false)
+
   return (
     <form
       className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2"
-      onSubmit={(e) => {
+      onSubmit={async (e) => {
         e.preventDefault()
-        // Ouvre un email pré-rempli; remplace si tu branches un backend
+        setSent(false)
+        setError(false)
         const form = e.currentTarget as HTMLFormElement
         const data = new FormData(form)
-        const name = data.get('name') as string
-        const email = data.get('email') as string
-        const subject = data.get('subject') as string
-        const message = data.get('message') as string
-        const mailto = `mailto:contact@minutezen.fr?subject=${encodeURIComponent(
-          subject || 'Message MinuteZen'
-        )}&body=${encodeURIComponent(
-          `Nom: ${name}\nEmail: ${email}\n\n${message}`
-        )}`
-        window.location.href = mailto
+        const res = await fetch('/api/contact', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: data.get('name'),
+            email: data.get('email'),
+            subject: data.get('subject'),
+            message: data.get('message'),
+          }),
+        })
+        if (res.ok) {
+          setSent(true)
+          form.reset()
+        } else {
+          setError(true)
+        }
       }}
     >
       <div className="sm:col-span-1">
@@ -80,6 +91,12 @@ export default function ContactForm() {
           Envoyer
         </button>
       </div>
+      {sent && (
+        <p className="sm:col-span-2 text-sm text-green-600">Votre message a été envoyé.</p>
+      )}
+      {error && (
+        <p className="sm:col-span-2 text-sm text-red-600">Une erreur est survenue.</p>
+      )}
     </form>
   )
 }


### PR DESCRIPTION
## Summary
- add API route to send emails with Resend
- send contact form data to the new API and display status messages

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ec11819483289dff409eff12ac5b