### PR TITLE
feat: use sender api key for emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Create a production build:
 npm run build
 ```
 
+## Environment Variables
+
+To enable email sending from the contact form, set the `SENDER_API_KEY` environment variable with your Sender API key.
+

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -3,23 +3,23 @@ import { NextResponse } from 'next/server'
 export async function POST(request: Request) {
   const { name, email, subject, message } = await request.json()
 
-  // In development or test environments the RESEND_API_KEY might be
+  // In development or test environments the SENDER_API_KEY might be
   // missing. Instead of throwing an error and preventing the form from
   // working, simply log the message and return a success response.
-  if (!process.env.RESEND_API_KEY) {
-    console.warn('RESEND_API_KEY is not set. Skipping email send.')
+  if (!process.env.SENDER_API_KEY) {
+    console.warn('SENDER_API_KEY is not set. Skipping email send.')
     return NextResponse.json({ success: true })
   }
 
   try {
-    const res = await fetch('https://api.resend.com/emails', {
+    const res = await fetch('https://api.sender.net/email', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+        Authorization: `Bearer ${process.env.SENDER_API_KEY}`,
       },
       body: JSON.stringify({
-        from: 'Contact Form <onboarding@resend.dev>',
+        from: 'Contact Form <no-reply@minutezen.fr>',
         to: ['contact@minutezen.fr'],
         subject: subject || 'Message MinuteZen',
         reply_to: email,


### PR DESCRIPTION
## Summary
- switch contact endpoint to use SENDER_API_KEY and Sender API
- document SENDER_API_KEY requirement

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68c6c97f3b4c8328957ca9806874c1a6