### PR TITLE
Switch contact form to OVH SMTP and sync pack audio leads with Sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,18 @@ npm run build
 
 ## Environment Variables
 
-To enable email sending from the contact form, set the `SENDER_API_KEY` environment variable with your Sender API key.
+Configure the following variables to enable form submissions:
+
+| Variable | Description |
+| --- | --- |
+| `SMTP_HOST` | OVH/Roundcube SMTP host (e.g. `ssl0.ovh.net`). |
+| `SMTP_PORT` | SMTP port, defaults to `465`. |
+| `SMTP_SECURE` | Set to `false` to disable implicit TLS (defaults to `true`). |
+| `SMTP_USERNAME` | SMTP account username. |
+| `SMTP_PASSWORD` | SMTP account password. |
+| `SMTP_FROM` | Email address used as envelope sender (defaults to `SMTP_USERNAME`). |
+| `SMTP_FROM_NAME` | Optional display name for the From header. |
+| `CONTACT_TO` | Comma-separated list of recipients for contact form submissions. |
+| `SENDER_API_KEY` | Sender API key used to subscribe leads from the Pack Audio form. |
+| `SENDER_LIST_ID` | Sender list ID where Pack Audio leads should be added. |
 

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,35 +1,243 @@
+import net from 'node:net'
+import tls from 'node:tls'
 import { NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+
+type SMTPOptions = {
+  host: string
+  port: number
+  secure: boolean
+  username?: string
+  password?: string
+}
+
+type PendingResponse = {
+  expected: number[]
+  resolve: (response: SMTPResponse) => void
+  reject: (error: Error) => void
+}
+
+type SMTPResponse = {
+  code: number
+  message: string
+}
+
+class SMTPClient {
+  private socket: net.Socket | tls.TLSSocket
+  private buffer = ''
+  private queue: PendingResponse[] = []
+  private responses: SMTPResponse[] = []
+  private current: { code: number; lines: string[] } | null = null
+  private closed = false
+
+  constructor(socket: net.Socket | tls.TLSSocket) {
+    this.socket = socket
+    this.socket.setEncoding('utf8')
+    this.socket.on('data', (chunk) => {
+      this.buffer += chunk
+      this.processBuffer()
+    })
+    this.socket.on('error', (err) => {
+      while (this.queue.length) {
+        this.queue.shift()?.reject(err)
+      }
+    })
+    this.socket.on('close', () => {
+      this.closed = true
+      while (this.queue.length) {
+        this.queue
+          .shift()
+          ?.reject(new Error('SMTP connection closed unexpectedly'))
+      }
+    })
+  }
+
+  async wait(expected: number[]) {
+    return new Promise<SMTPResponse>((resolve, reject) => {
+      this.queue.push({ expected, resolve, reject })
+      this.drain()
+    })
+  }
+
+  async command(command: string, expected: number[]) {
+    if (this.closed) {
+      throw new Error('SMTP connection is closed')
+    }
+    return new Promise<SMTPResponse>((resolve, reject) => {
+      this.queue.push({ expected, resolve, reject })
+      this.socket.write(`${command}\r\n`)
+      this.drain()
+    })
+  }
+
+  async data(payload: string, expected: number[]) {
+    if (this.closed) {
+      throw new Error('SMTP connection is closed')
+    }
+    return new Promise<SMTPResponse>((resolve, reject) => {
+      this.queue.push({ expected, resolve, reject })
+      this.socket.write(payload)
+      this.drain()
+    })
+  }
+
+  private processBuffer() {
+    while (true) {
+      const delimiterIndex = this.buffer.indexOf('\r\n')
+      if (delimiterIndex === -1) {
+        return
+      }
+      const line = this.buffer.slice(0, delimiterIndex)
+      this.buffer = this.buffer.slice(delimiterIndex + 2)
+      if (!line) {
+        continue
+      }
+      const code = Number.parseInt(line.slice(0, 3), 10)
+      const continuation = line[3] === '-'
+      const text = line.length > 4 ? line.slice(4) : ''
+      if (!this.current) {
+        this.current = { code, lines: [text] }
+      } else {
+        this.current.lines.push(text)
+      }
+      if (!continuation) {
+        const response: SMTPResponse = {
+          code: this.current.code,
+          message: this.current.lines.join('\n'),
+        }
+        this.current = null
+        this.responses.push(response)
+        this.drain()
+      }
+    }
+  }
+
+  private drain() {
+    while (this.queue.length && this.responses.length) {
+      const pending = this.queue.shift()!
+      const response = this.responses.shift()!
+      if (!pending.expected.includes(response.code)) {
+        pending.reject(
+          new Error(`SMTP command failed with ${response.code}: ${response.message}`)
+        )
+      } else {
+        pending.resolve(response)
+      }
+    }
+  }
+
+  close() {
+    if (!this.closed) {
+      this.socket.end()
+    }
+  }
+}
+
+async function connectSMTP(options: SMTPOptions) {
+  const socket = options.secure
+    ? tls.connect({
+        host: options.host,
+        port: options.port,
+        servername: options.host,
+      })
+    : net.createConnection({ host: options.host, port: options.port })
+
+  await new Promise<void>((resolve, reject) => {
+    const connectEvent = options.secure ? 'secureConnect' : 'connect'
+    socket.once(connectEvent, () => resolve())
+    socket.once('error', (err) => reject(err))
+  })
+
+  return new SMTPClient(socket)
+}
+
+async function sendSMTPMail(
+  options: SMTPOptions,
+  message: {
+    envelopeFrom: string
+    headerFrom: string
+    to: string[]
+    replyTo?: string
+    subject: string
+    text: string
+  }
+) {
+  const client = await connectSMTP(options)
+
+  try {
+    await client.wait([220])
+    await client.command('EHLO minutezen.fr', [250])
+
+    if (options.username && options.password) {
+      await client.command('AUTH LOGIN', [334])
+      await client.command(
+        Buffer.from(options.username, 'utf8').toString('base64'),
+        [334]
+      )
+      await client.command(
+        Buffer.from(options.password, 'utf8').toString('base64'),
+        [235]
+      )
+    }
+
+    await client.command(`MAIL FROM:<${message.envelopeFrom}>`, [250])
+    for (const recipient of message.to) {
+      await client.command(`RCPT TO:<${recipient}>`, [250, 251])
+    }
+    await client.command('DATA', [354])
+
+    const headers = [
+      `From: ${message.headerFrom}`,
+      `To: ${message.to.join(', ')}`,
+      `Subject: ${message.subject}`,
+      'MIME-Version: 1.0',
+      'Content-Type: text/plain; charset=utf-8',
+    ]
+    if (message.replyTo) {
+      headers.push(`Reply-To: ${message.replyTo}`)
+    }
+
+    const body = `${headers.join('\r\n')}\r\n\r\n${message.text}`
+      .replace(/\r?\n/g, '\r\n')
+      .replace(/\n\./g, '\n..')
+
+    await client.data(`${body}\r\n.\r\n`, [250])
+    await client.command('QUIT', [221, 250])
+  } finally {
+    client.close()
+  }
+}
 
 export async function POST(request: Request) {
   const { name, email, subject, message } = await request.json()
 
-  // In development or test environments the SENDER_API_KEY might be
-  // missing. Instead of throwing an error and preventing the form from
-  // working, simply log the message and return a success response.
-  if (!process.env.SENDER_API_KEY) {
-    console.warn('SENDER_API_KEY is not set. Skipping email send.')
+  const host = process.env.SMTP_HOST
+  const port = process.env.SMTP_PORT ? Number.parseInt(process.env.SMTP_PORT, 10) : 465
+  const username = process.env.SMTP_USERNAME
+  const password = process.env.SMTP_PASSWORD
+  const fromEmail = process.env.SMTP_FROM || username
+  const fromName = process.env.SMTP_FROM_NAME
+  const to = process.env.CONTACT_TO || 'contact@minutezen.fr'
+  const secure = process.env.SMTP_SECURE !== 'false'
+
+  if (!host || !fromEmail) {
+    console.warn('SMTP credentials are not fully configured. Skipping email send.')
     return NextResponse.json({ success: true })
   }
 
   try {
-    const res = await fetch('https://api.sender.net/email', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.SENDER_API_KEY}`,
-      },
-      body: JSON.stringify({
-        from: 'Contact Form <no-reply@minutezen.fr>',
-        to: ['contact@minutezen.fr'],
+    await sendSMTPMail(
+      { host, port, secure, username, password },
+      {
+        envelopeFrom: fromEmail,
+        headerFrom: fromName ? `${fromName} <${fromEmail}>` : fromEmail,
+        to: to.split(',').map((recipient) => recipient.trim()).filter(Boolean),
+        replyTo: email,
         subject: subject || 'Message MinuteZen',
-        reply_to: email,
         text: `Nom: ${name}\nEmail: ${email}\n\n${message}`,
-      }),
-    })
-
-    if (!res.ok) {
-      return NextResponse.json({ error: 'Failed to send email' }, { status: 500 })
-    }
+      }
+    )
   } catch (err) {
     console.error('Error while sending contact email', err)
     return NextResponse.json({ error: 'Failed to send email' }, { status: 500 })

--- a/app/api/pack-audio/route.ts
+++ b/app/api/pack-audio/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const { name, email } = await request.json()
+
+  if (!name || !email) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  }
+
+  const apiKey = process.env.SENDER_API_KEY
+  const listId = process.env.SENDER_LIST_ID
+
+  if (!apiKey || !listId) {
+    console.warn('Sender configuration missing. Skipping subscription call.')
+    return NextResponse.json({ success: true })
+  }
+
+  try {
+    const response = await fetch('https://api.sender.net/v2/contacts', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        email,
+        firstname: name,
+        lists: [listId],
+        triggered_from: 'minutezen-pack-audio',
+      }),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.error('Failed to sync contact with Sender:', errorText)
+      return NextResponse.json({ error: 'Failed to save contact' }, { status: 500 })
+    }
+  } catch (err) {
+    console.error('Unable to call Sender API', err)
+    return NextResponse.json({ error: 'Failed to save contact' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}


### PR DESCRIPTION
## Summary
- implement a lightweight SMTP client so the contact form sends email via OVH/Roundcube credentials
- add a dedicated `/api/pack-audio` route and update the pack download form to call Sender with the visitor name and email
- document the new SMTP and Sender environment variables needed to configure the integrations

## Testing
- `npm run lint` *(fails: command prompts for interactive ESLint setup and cannot complete in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d530f55ac48328a84a2c159167f42e