### PR TITLE
Use Sender automation endpoint for Pack Audio form

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,5 @@ Configure the following variables to enable form submissions:
 | `SMTP_FROM` | Email address used as envelope sender (defaults to `SMTP_USERNAME`). |
 | `SMTP_FROM_NAME` | Optional display name for the From header. |
 | `CONTACT_TO` | Comma-separated list of recipients for contact form submissions. |
-| `SENDER_API_KEY` | Sender API key used to subscribe leads from the Pack Audio form. |
-| `SENDER_LIST_ID` | Sender list ID where Pack Audio leads should be added. |
+| `SENDER_API` | Sender webhook endpoint used to subscribe Pack Audio leads to the `packaudio` automation. |
 

--- a/app/api/pack-audio/route.ts
+++ b/app/api/pack-audio/route.ts
@@ -7,26 +7,23 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
   }
 
-  const apiKey = process.env.SENDER_API_KEY
-  const listId = process.env.SENDER_LIST_ID
+  const senderEndpoint = process.env.SENDER_API
 
-  if (!apiKey || !listId) {
+  if (!senderEndpoint) {
     console.warn('Sender configuration missing. Skipping subscription call.')
     return NextResponse.json({ success: true })
   }
 
   try {
-    const response = await fetch('https://api.sender.net/v2/contacts', {
+    const response = await fetch(senderEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
         email,
         firstname: name,
-        lists: [listId],
-        triggered_from: 'minutezen-pack-audio',
+        automation: 'packaudio',
       }),
     })
 


### PR DESCRIPTION
## Summary
- send Pack Audio leads to the Sender endpoint defined by `SENDER_API`
- include the `packaudio` automation identifier in the payload
- document the new `SENDER_API` environment variable

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d54a68ac408328a810885f46632fcb